### PR TITLE
Cleanup

### DIFF
--- a/etc/schemas/2022/01/01/CreateOrderForUseInPracticeRequest.xsd
+++ b/etc/schemas/2022/01/01/CreateOrderForUseInPracticeRequest.xsd
@@ -15,7 +15,7 @@
 	</element>
 	<complexType name="CreateOrderForUseInPracticeRequestType">
 		<sequence>
-			<element name="CreatedBy" type="mc160:ModificatorType"/>
+			<element name="CreatedBy" type="mc160:ModificatorType" minOccurs="0"/>
 			<element name="ReportedBy" type="mc160:ModificatorType" minOccurs="0"/>
 			<element name="Warrant" type="mc160:WarrantForUseInPracticeType" maxOccurs="unbounded"/>
 		</sequence>

--- a/etc/schemas/2022/01/01/DrugCatalogEntry.xsd
+++ b/etc/schemas/2022/01/01/DrugCatalogEntry.xsd
@@ -11,7 +11,6 @@
     <include schemaLocation="ATC.xsd"/>
     <include schemaLocation="Partable.xsd"/>
     <include schemaLocation="ReservedForNonSubstitutableDrugMedications.xsd"/>
-    <include schemaLocation="PackageNumber.xsd"/>
     <include schemaLocation="ValidFromDate.xsd"/>
     <include schemaLocation="ValidToDate.xsd"/>
 	
@@ -27,7 +26,6 @@
 			<element name="ATC" type="mc160:ATCType" minOccurs="0"/>
 			<element name="Partable" type="mc160:PartableType" minOccurs="0" />
 			<element name="ReservedForNonSubstitutableDrugMedications" type="mc160:ReservedForNonSubstitutableDrugMedicationsType" minOccurs="0" />
-            <element name="PackageNumber" type="mc160:PackageNumberType" minOccurs="0"/>
 			<element name="ValidFrom" type="mc160:ValidFromDateType" />
             <element name="ValidTo" type="mc160:ValidToDateType" minOccurs="0"/>
         </sequence>

--- a/etc/schemas/2022/01/01/IncludeEffectuationsOnAttachedWarrants.xsd
+++ b/etc/schemas/2022/01/01/IncludeEffectuationsOnAttachedWarrants.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:mc160="http://fmk-teknik.dk/160"
+        targetNamespace="http://fmk-teknik.dk/160"
+        elementFormDefault="qualified" attributeFormDefault="unqualified">
+    
+	<element name="IncludeEffectuationsOnAttachedWarrants" type="mc160:IncludeEffectuationsOnAttachedWarrantsType">
+		<annotation>
+			<documentation xml:lang="en-GB">Indication whether effectuations on attached warrants are to be fetched</documentation>
+			<documentation xml:lang="da-DK">Angivelse om hvorledes effektueringer på udleveringsgrundlag tilknyttet lægemiddelordinationer ønskes fremsøgt</documentation>
+		</annotation>
+	</element>
+
+	<complexType name="IncludeEffectuationsOnAttachedWarrantsType"/>
+</schema>

--- a/etc/schemas/2022/01/01/IncludeEffectuationsOnLooseWarrants.xsd
+++ b/etc/schemas/2022/01/01/IncludeEffectuationsOnLooseWarrants.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:mc160="http://fmk-teknik.dk/160"
+        targetNamespace="http://fmk-teknik.dk/160"
+        elementFormDefault="qualified" attributeFormDefault="unqualified">
+    
+	<element name="IncludeEffectuationsOnLooseWarrants" type="mc160:IncludeEffectuationsOnLooseWarrantsType">
+		<annotation>
+			<documentation xml:lang="en-GB">Indication whether effectuations on loose warrants are to be fetched</documentation>
+			<documentation xml:lang="da-DK">Angivelse om hvorledes effektueringer på løse udleveringsgrundlag ønskes fremsøgt</documentation>
+		</annotation>
+	</element>
+
+	<complexType name="IncludeEffectuationsOnLooseWarrantsType"/>
+</schema>

--- a/etc/schemas/2022/01/01/PackagedDispensingOverview.xsd
+++ b/etc/schemas/2022/01/01/PackagedDispensingOverview.xsd
@@ -30,7 +30,6 @@
 			<element name="PrescribedDrug" type="mc160:DrugType"/>
 			<element name="PlannedDrugIdentifier" type="mc160:DrugIdentifierType" minOccurs="0"/>
 			<element name="ActualDrug" type="mc160:DrugType"/>
-			<element name="PackageNumber" type="mc160:PackageNumberType" minOccurs="0"/>
 			<element name="LastPeriodDrugIdentifier" type="mc160:DrugIdentifierType" minOccurs="0"/>
 			<element name="Amount" type="mc160:DoseQuantityType" minOccurs="0"/>
 			<element name="PrescribedBy" type="mc160:ModificatorType"/>

--- a/etc/schemas/2022/01/01/PackagedDrug.xsd
+++ b/etc/schemas/2022/01/01/PackagedDrug.xsd
@@ -18,7 +18,6 @@
         <sequence>
             <element name="DispensingIdentifier" type="mc160:DispensingIdentifierType"/>
             <element name="Drug" type="mc160:DrugType"/>
-            <element name="PackageNumber" type="mc160:PackageNumberType" minOccurs="0"/>
             <element name="ModificationMetadata" type="mc160:ModificationMetadataType" minOccurs="0" maxOccurs="unbounded"/>
         </sequence>
     </complexType>

--- a/etc/schemas/2022/01/01/SearchEffectuationsRequest.xsd
+++ b/etc/schemas/2022/01/01/SearchEffectuationsRequest.xsd
@@ -6,6 +6,8 @@
 
 	<include schemaLocation="PersonIdentifier.xsd"/>
 	<include schemaLocation="EffectuationDateTime.xsd"/>
+	<include schemaLocation="IncludeEffectuationsOnAttachedWarrants.xsd"/>
+	<include schemaLocation="IncludeEffectuationsOnLooseWarrants.xsd"/>
 
 	<element name="SearchEffectuationsRequest" type="mc160:SearchEffectuationsRequestType">
 		<annotation>
@@ -18,8 +20,8 @@
 			<element name="PersonIdentifier" type="mc160:PersonIdentifierType" />
 			<element name="FromDateTime" type="mc160:EffectuationDateTimeType" minOccurs="0"/>
 			<element name="ToDateTime" type="mc160:EffectuationDateTimeType" minOccurs="0"/>
-			<element name="IncludeEffectuationsOnWarrantsOnDrugMedications" type="boolean" minOccurs="0"/>
-			<element name="IncludeEffectuationsNotOnDrugMedications" type="boolean" minOccurs="0"/>
+			<element name="IncludeEffectuationsOnAttachedWarrants" type="mc160:IncludeEffectuationsOnAttachedWarrantsType" minOccurs="0"/>
+			<element name="IncludeEffectuationsOnLooseWarrants" type="mc160:IncludeEffectuationsOnLooseWarrantsType" minOccurs="0"/>
 		</sequence>
 	</complexType>
 </schema>

--- a/etc/schemas/2022/01/01/SearchEffectuationsResponse.xsd
+++ b/etc/schemas/2022/01/01/SearchEffectuationsResponse.xsd
@@ -19,7 +19,7 @@
 		<sequence>
 			<element name="PersonIdentifier" type="mc160:PersonIdentifierType" />
 			<element name="WarrantsOnDrugMedication" type="mc160:WarrantEffectuationsOnDrugMedicationType" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="Warrant" type="mc160:EffectuationsOnWarrantType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="LooseWarrant" type="mc160:EffectuationsOnWarrantType" minOccurs="0" maxOccurs="unbounded"/>
 		</sequence>
 	</complexType>
 </schema>


### PR DESCRIPTION
1. Fjern PackageNumber fra steder i DD hvor de alligevel ikke anvendes
2. Oprydning i SearchEffectuations så det matcher de forventede steder med effektueringer i 1.6.0
3. OrderForUseInPractice havde fejl i forhold til CreatedBy på rod i forhold til under-elementer.