### PR TITLE
Explicitly state what type from and to are

### DIFF
--- a/etc/schemas/2022/01/01/RegistrationValidityPeriod.xsd
+++ b/etc/schemas/2022/01/01/RegistrationValidityPeriod.xsd
@@ -3,7 +3,7 @@
 		xmlns:mc160="http://fmk-teknik.dk/160"
 		targetNamespace="http://fmk-teknik.dk/160"
 		elementFormDefault="qualified" attributeFormDefault="unqualified">
-	
+
 	<element name="RegistrationValidityPeriod" type="mc160:RegistrationValidityPeriodType">
 		<annotation>
 			<documentation xml:lang="en-GB">Date and time for expiration</documentation>
@@ -13,8 +13,8 @@
 
 	<complexType name="RegistrationValidityPeriodType">
 		<sequence>
-			<element name="From" type="mc160:ValidityDateTimeType"/>
-			<element name="To" type="mc160:ValidityDateTimeType"/>
+			<element name="FromDateTime" type="mc160:ValidityDateTimeType"/>
+			<element name="ToDateTime" type="mc160:ValidityDateTimeType"/>
 		</sequence>
 	</complexType>
 


### PR DESCRIPTION
Previously, the elements were simply named `From` and `To`. That made it easy to assume they represented plain dates, even though in practice they carried time information as well. By renaming them to `FromDateTime` and `ToDateTime`, the intention is clearer, they are `dateTime` values, not just `date`.

When working with generated code, the distinction between `date` and `dateTime` isn’t always obvious from context. That’s why it’s important to always declare `date` and `dateTime` explicitly in the schema. It prevents misinterpretation and ensures consistency between the XML and the generated types.