### PR TITLE
FMK-11219 added "expected way of handover" to LMO

### DIFF
--- a/etc/schemas/2022/01/01/CreateDrugMedication.xsd
+++ b/etc/schemas/2022/01/01/CreateDrugMedication.xsd
@@ -21,6 +21,7 @@
 	<include schemaLocation="CreateWarrant.xsd"/>
 	<include schemaLocation="WarrantIdentifier.xsd"/>
 	<include schemaLocation="ReimbursementClause.xsd"/>
+	<include schemaLocation="TypeOfMedicineHandover.xsd"/>
 
 	<complexType name="CreateDrugMedicationType">
 		<annotation>
@@ -41,6 +42,7 @@
 			<element name="Dosage" type="mc160:DosageForRequestType"/>
 			<element name="SubstitutionAllowed" type="mc160:SubstitutionAllowedType"/>
 			<element name="Effectuation" type="mc160:CreateEffectuationType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="ExpectedTypeOfHandover" type="mc160:TypeOfMedicineHandoverType"/>
 			<element name="CreateWarrant" type="mc160:CreateWarrantType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="AttachWarrant" type="mc160:WarrantIdentifierType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="ReimbursementApprovedCode" type="mc160:ReimbursementCodeType" minOccurs="0"/>

--- a/etc/schemas/2022/01/01/DrugMedication.xsd
+++ b/etc/schemas/2022/01/01/DrugMedication.xsd
@@ -26,6 +26,7 @@
 	<include schemaLocation="Warrant.xsd"/>
 	<include schemaLocation="InvalidWarrant.xsd"/>
 	<include schemaLocation="IsDoseDispensed.xsd"/>
+	<include schemaLocation="TypeOfMedicineHandover.xsd"/>
 
 	<complexType name="DrugMedicationType">
 		<annotation>
@@ -55,9 +56,14 @@
 				<element name="PlannedAdministrationForPreviousVersion" type="mc160:PlannedAdministrationForPreviousVersionType"/>
 			</choice>
 			<element name="SubstitutionAllowed" type="mc160:SubstitutionAllowedType" minOccurs="0"/>
+			<element name="ExpectedTypeOfHandover" type="mc160:TypeOfMedicineHandoverType"/>
 			<element name="Warrant" type="mc160:WarrantType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="InvalidWarrant" type="mc160:InvalidWarrantType" minOccurs="0" maxOccurs="unbounded"/>
 			<element name="ReimbursementApprovedCode" type="mc160:ReimbursementCodeType" minOccurs="0"/>
 		</sequence>
 	</complexType>
+
+
+
+
 </schema>

--- a/etc/schemas/2022/01/01/TypeOfMedicineHandover.xsd
+++ b/etc/schemas/2022/01/01/TypeOfMedicineHandover.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+		xmlns:mc160="http://fmk-teknik.dk/160"
+		targetNamespace="http://fmk-teknik.dk/160"
+		elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<element name="TypeOfMedicineHandover" type="mc160:TypeOfMedicineHandoverType">
+		<annotation>
+			<documentation xml:lang="en-GB">Used to specify af way of handing over medicine.</documentation>
+			<documentation xml:lang="da-DK">Bruges til angivelse af en måde at udlevere medicin.</documentation>
+		</annotation>
+	</element>
+
+	<simpleType name="TypeOfMedicineHandoverType">
+		<union memberTypes="mc160:PredefinedTypeOfMedicineHandoverType mc160:UndefinedTypeOfMedicineHandoverType"/>
+	</simpleType>
+
+	<simpleType name="PredefinedTypeOfMedicineHandoverType">
+		<restriction base="string">
+			<enumeration value="TreatmentHandOver"/>
+			<enumeration value="Prescription"/>
+			<enumeration value="DosisPrescription"/>
+			<enumeration value="HospitalPharmacyPrescription"/>
+			<enumeration value="UseInPractice"/>
+			<enumeration value="WithoutPrescription"/>
+		</restriction>
+	</simpleType>
+
+	<simpleType name="UndefinedTypeOfMedicineHandoverType">
+		<restriction base="string">
+			<maxLength value="100"/>
+		</restriction>
+	</simpleType>
+
+</schema>

--- a/etc/schemas/2022/01/01/UpdateDrugMedication.xsd
+++ b/etc/schemas/2022/01/01/UpdateDrugMedication.xsd
@@ -18,7 +18,8 @@
 	<include schemaLocation="DosageForRequest.xsd"/>
 	<include schemaLocation="SubstitutionAllowed.xsd"/>
 	<include schemaLocation="ReimbursementClause.xsd"/>
-	
+	<include schemaLocation="TypeOfMedicineHandover.xsd"/>
+
 	<element name="UpdateDrugMedication" type="mc160:UpdateDrugMedicationType">
 		<annotation>
 			<documentation xml:lang="en-GB">An overview of the drug medication (a medication on the medicine card), used for update</documentation>
@@ -30,7 +31,7 @@
 			<element name="Identifier" type="mc160:DrugMedicationIdentifierType"/>
 			<element name="ParentIdentifier" type="mc160:DrugMedicationIdentifierType" minOccurs="0"/>
 			<element name="ModifiedBy" type="mc160:ModificatorType" minOccurs="0"/>
-            <element name="FollowUpDates" type="mc160:FollowUpDatesType" minOccurs="0"/>
+      <element name="FollowUpDates" type="mc160:FollowUpDatesType" minOccurs="0"/>
 			<element name="Pause" type="mc160:PauseType" minOccurs="0"/>
 			<element name="Type" type="mc160:DrugMedicationTypeType" minOccurs="0" />
 			<element name="HasNegativeConsent" type="mc160:HasNegativeConsentType" minOccurs="0"/>
@@ -40,6 +41,7 @@
 			<element name="Drug" type="mc160:DrugType"/>
 			<element name="Dosage" type="mc160:DosageForRequestType"/>
 			<element name="SubstitutionAllowed" type="mc160:SubstitutionAllowedType"/>
+      <element name="ExpectedTypeOfHandover" type="mc160:TypeOfMedicineHandoverType"/>
 			<element name="ReimbursementApprovedCode" type="mc160:ReimbursementCodeType" minOccurs="0"/>
 			<element name="ModificationMetadata" type="mc160:ModificationMetadataType" minOccurs="0" maxOccurs="unbounded"/>
 		</sequence>


### PR DESCRIPTION
Kom meget gerne med bud på bedre navngivning og overvej meget gerne om det er de korrekte enum værdier.

Fra kliniskløsningsbeskrivelse er der følgende muligheder:

- Recept - almindelige recepter (til udlevering fra private apoteker)
- Dosisrecept (til udlevering fra private apoteker)
- Udlevering af medicin fra sygehusapotek 
- Direkte udlevering (til registrering af udlevering direkte fra eget lager, fx lokalt medicindepot, sygehus afdeling, praktiserende læge eller tandlæge)
- 'Købes uden recept' er medicin der kan købes i håndkøb og i detailhandlen. (Lægemidler, kosttilskud eller vitaminer som for denne behandling ikke er receptpligtig). Typen er speciel, da et reelt udleveringsgrundlag ikke er nødvendigt, men der er en markering på lægemiddelordinationen.
- Løs recept. Man kan ikke oprette et udleveringsgrundlag af denne type, men det opstår, når apoteket ekspederer en papir eller telefon recept.


From 1.6.0, on DrugMedication, it is now required to specify the "expected way of handover" (udleveringsgrundlag)